### PR TITLE
Prune subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,5 +30,13 @@ Only definitions that aren't already in node-build's lookup path (`NODE_BUILD_DE
 
 - `NODE_BUILD_DEFINITIONS` can be a list of colon-separated paths that get additionally searched when looking up build definitions. All nodenv plugins' `share/node-build/` directories are appended to this path. Definitions already found in these paths will be skipped (unless `--force`).
 
+## Cleanup/Pruning
+
+In normal operation, build definitions will gradually build up in this plugin's `share/node-build` directory (or elsewhere if overridden with `--destination`). Eventually, as the scraped definitions are added to node-build itself, these user-scraped definitions will become duplicates when their node-build installation is updated. In order to ensure one is frequently running on the "proper" build definitions from node-build, any duplicates in the plugin directory ought to be removed.
+
+    $ nodenv prune-version-defs
+
+This subcommand removes (or lists with `--dry-run`) any duplicate build definitions. Like `update-version-defs`, `--destination <dir>` overrides the default value of `<plugin-root>/share/node-build` as the directory from which duplicates are removed. Duplicates are searched for under `NODE_BUILD_DEFINITIONS` and are determined by both filename *and* contents. The file contents check can be overridden with `--force`,  which will delete duplicates based solely on filename.
+
 [nodenv]: https://github.com/OiNutter/nodenv
 [node-build]: https://github.com/OiNutter/node-build

--- a/README.md
+++ b/README.md
@@ -38,5 +38,7 @@ In normal operation, build definitions will gradually build up in this plugin's 
 
 This subcommand removes (or lists with `--dry-run`) any duplicate build definitions. Like `update-version-defs`, `--destination <dir>` overrides the default value of `<plugin-root>/share/node-build` as the directory from which duplicates are removed. Duplicates are searched for under `NODE_BUILD_DEFINITIONS` and are determined by both filename *and* contents. The file contents check can be overridden with `--force`,  which will delete duplicates based solely on filename.
 
+This subcommand is silent by default, only printing removed duplicates if `--verbose`. (`--dry-run` implies `--verbose`)
+
 [nodenv]: https://github.com/OiNutter/nodenv
 [node-build]: https://github.com/OiNutter/node-build

--- a/bin/nodenv-prune-version-defs
+++ b/bin/nodenv-prune-version-defs
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+#
+# Summary: Find and remove duplicate build definitions
+#
+# Usage: nodenv prune-version-defs [-f] [-d <dir>] [-n] [-v]
+#
+# Scrapes nodejs.org and iojs.org to create build definitions for node
+# versions not yet available to node-build
+#
+#   -d/--destination   Directory from which duplicate build definitions will
+#                      be removed
+#   -f/--force         Remove duplicates even if file contents differ
+#   -n/--dry-run       List files that would be removed, without doing so;
+#                      implies --verbose
+#   -v/--verbose       List duplicate files as they are removed
+#
+
+set -e
+
+resolve_link() {
+  $(type -p greadlink readlink | head -1) "$1"
+}
+
+abs_dirname() {
+  local cwd="$PWD"
+  local path="$1"
+
+  while [ -n "$path" ]; do
+    cd "${path%/*}"
+    local name="${path##*/}"
+    path="$(resolve_link "$name" || true)"
+  done
+
+  pwd
+  cd "$cwd"
+}
+
+INSTALL_PREFIX="$(abs_dirname "${BASH_SOURCE[0]}")/.."
+
+# prepend our share dir to defs path; the first path will be the write target
+NODE_BUILD_DEFINITIONS="${INSTALL_PREFIX}/share/node-build:${NODE_BUILD_DEFINITIONS}"
+
+# Add `share/node-build/` directory from each nodenv plugin to the list of
+# paths where build definitions are looked up.
+shopt -s nullglob
+for plugin_path in "$NODENV_ROOT"/plugins/*/share/node-build; do
+  NODE_BUILD_DEFINITIONS="${NODE_BUILD_DEFINITIONS%:}:${plugin_path}"
+done
+export NODE_BUILD_DEFINITIONS
+shopt -u nullglob
+
+# Provide nodenv completions
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --complete )
+      echo --destination
+      echo --dry-run
+      echo --force
+      echo --help
+      echo --verbose
+      exit ;;
+    -d | --destination )
+      shift
+      # overwrite the defs write target
+      NODE_BUILD_DEFINITIONS="$(abs_dirname "${1%/}/"):${NODE_BUILD_DEFINITIONS}" ;;
+    -f | --force )
+      FORCE=true ;;
+    -h | --help )
+      exec nodenv-help update-version-defs ;;
+    -n | --dry-run )
+      DRY_RUN=true
+      VERBOSE=true ;;
+    -v | --verbose )
+      VERBOSE=true ;;
+    * )
+      nodenv-help --usage update-version-defs >&2
+      exit 1;;
+  esac
+  shift
+done
+
+target_dir="$(abs_dirname "${NODE_BUILD_DEFINITIONS%%:*}"/)"
+remaining_dirs="${NODE_BUILD_DEFINITIONS#*:}"
+
+for file in "$target_dir"/*; do
+  file="$(basename "$file")"
+  duplicate="$target_dir/$file"
+  IFS=:
+  for dir in $remaining_dirs; do
+    original="$dir/$file"
+    if [ -f "$original" ]; then
+      if diff -q "$original" "$duplicate" >&2 || [ -n "$FORCE" ]; then
+        [ -z "$VERBOSE" ] || echo "$duplicate"
+        [ -n "$DRY_RUN" ] || rm -f "$duplicate"
+      fi
+    fi
+  done
+done

--- a/bin/nodenv-prune-version-defs
+++ b/bin/nodenv-prune-version-defs
@@ -87,6 +87,8 @@ for file in "$target_dir"/*; do
   duplicate="$target_dir/$file"
   IFS=:
   for dir in $remaining_dirs; do
+    if [ "$target_dir" -ef "$dir" ]; then continue; fi
+
     original="$dir/$file"
     if [ -f "$original" ]; then
       if diff -q "$original" "$duplicate" >&2 || [ -n "$FORCE" ]; then

--- a/bin/nodenv-update-version-defs
+++ b/bin/nodenv-update-version-defs
@@ -41,7 +41,7 @@ NODE_BUILD_DEFINITIONS="${INSTALL_PREFIX}/share/node-build:${NODE_BUILD_DEFINITI
 # paths where build definitions are looked up.
 shopt -s nullglob
 for plugin_path in "$NODENV_ROOT"/plugins/*/share/node-build; do
-  NODE_BUILD_DEFINITIONS="${NODE_BUILD_DEFINITIONS}:${plugin_path}"
+  NODE_BUILD_DEFINITIONS="${NODE_BUILD_DEFINITIONS%:}:${plugin_path}"
 done
 export NODE_BUILD_DEFINITIONS
 shopt -u nullglob

--- a/bin/nodenv-update-version-defs
+++ b/bin/nodenv-update-version-defs
@@ -2,7 +2,7 @@
 #
 # Summary: Create build definitions from nodejs.org and iojs.org
 #
-# Usage: nodenv update-defs [-f] [-d <dir>]
+# Usage: nodenv update-version-defs [-f] [-d <dir>] [-n] [--nodejs] [--iojs]
 #
 # Scrapes nodejs.org and iojs.org to create build definitions for node
 # versions not yet available to node-build
@@ -10,6 +10,12 @@
 #   -d/--destination   Directory where build definitions will be written
 #   -f/--force         Write build definitions that already exist somewhere in
 #                      NODE_BUILD_DEFINITIONS paths; possibly overwriting
+#   -n/--dry-run       List definitions that would be created; without doing so
+#
+#   --nodejs           Scrape nodejs.org for node definitions;
+#                      If none of --nodejs,--iojs are supplied, defaults to all
+#   --iojs             Scrape iojs.org for node definitions;
+#                      If none of --nodejs,--iojs are supplied, defaults to all
 #
 
 set -e


### PR DESCRIPTION
closes #2 

Adds subcommand `nodenv prune-version-defs` as a counterpart to `update-version-defs`

In the normal operation of `update-version-defs`, build definitions will gradually build up in the node-build-update-defs/share/node-build directory. Eventually, as the definitions are added to node-build itself, these definitions will become duplicates (when their node-build install is updated). In order to ensure one is frequently running on the "proper" build definitions (from node-build), any duplicates in the plugin directory ought to be removed.

This subcommand removes (or lists when `--dry-run`), any duplicate build definitions. Unless `--destination` is specified, the `node-build-update-defs/share/node-build` directory is the directory from which duplicates are removed. Filename and contents are used to determine duplicates; if same-named file is found elsewhere in `NODE_BUILD_DEFINITIONS`. With `--force`, one can override the file content check, which will delete duplicates based solely on filename.